### PR TITLE
add inotify-tools package to avoid error message after first request

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -1,2 +1,5 @@
 run.config:
   engine: elixir
+
+  dev_packages:
+    - inotify-tools


### PR DESCRIPTION
Without this package install, the message `[error] backend port not found: :inotifywait` is displayed in the console log by Phoenix after the first request.